### PR TITLE
Work/MP-70: Bruke default event mot idporten-cd og tillatte application.yaml

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: Syntax check workflows files (actionlint)
 on: [push]
 
 jobs:

--- a/.github/workflows/eid-maven-build.yml
+++ b/.github/workflows/eid-maven-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
         with:
-          file_or_dir: src/main/resources/application*.yml
+          file_or_dir: src/main/resources/application*.y*ml
           config_data: |
             extends: default
             rules:

--- a/.github/workflows/eid-spring-boot-build-publish-image-generic.yml
+++ b/.github/workflows/eid-spring-boot-build-publish-image-generic.yml
@@ -59,7 +59,7 @@ jobs:
         - name: yaml-lint
           uses: ibiqlik/action-yamllint@v3
           with:
-            file_or_dir: src/main/resources/application*.yml
+            file_or_dir: src/main/resources/application*.y*ml
             config_data: |
               extends: default
               rules:

--- a/.github/workflows/eid-spring-boot-build-publish-image.yml
+++ b/.github/workflows/eid-spring-boot-build-publish-image.yml
@@ -49,7 +49,7 @@ jobs:
         - name: yaml-lint
           uses: ibiqlik/action-yamllint@v3
           with:
-            file_or_dir: src/main/resources/application*.yml
+            file_or_dir: src/main/resources/application*.y*ml
             config_data: |
               extends: default
               rules:
@@ -113,10 +113,10 @@ jobs:
             ALLURE_USER: ${{ secrets.allure-user }}
             ALLURE_PASSWORD: ${{ secrets.allure-password }}
             MULTI_MODULE: "false"
-        - name: 'update cd'
+        - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
           uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4 # pin@v1.1.3
           with:
             token: ${{ secrets.eid-build-token }}
-            event-type: update-idporten-version
+            event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"application": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}"}'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}"}'

--- a/.github/workflows/test-job-output.yml
+++ b/.github/workflows/test-job-output.yml
@@ -29,7 +29,7 @@ jobs:
         - name: yaml-lint
           uses: ibiqlik/action-yamllint@v3
           with:
-            file_or_dir: src/main/resources/application*.yml
+            file_or_dir: src/main/resources/application*.y*ml
             config_data: |
               extends: default
               rules:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, Digitaliseringsdirektoratet (Digdir)
+Copyright (c) 2022, Digitaliseringsdirektoratet (Digdir)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # eid-github-workflows
+![Build Status](https://github.com/felleslosninger/eid-github-workflows/actions/workflows/check-syntax.yml/badge.svg)
 Github Action workflows for eID-group pipeline

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # eid-github-workflows
-![Build Status](https://github.com/felleslosninger/eid-github-workflows/actions/workflows/check-syntax.yml/badge.svg)
+![Build Status](https://github.com/felleslosninger/eid-github-workflows/actions/workflows/check-syntax.yml/badge.svg?branch=main)
+
+
 Github Action workflows for eID-group pipeline


### PR DESCRIPTION
Køyrde grønt mot Maskinporten (midlertidig testa mot denne branchen der) for application.yaml fil: https://github.com/felleslosninger/maskinporten/pull/64