### PR TITLE
PF-168 Add support for choosing Kustomize overlay

### DIFF
--- a/.github/workflows/eid-spring-boot-build-publish-image.yml
+++ b/.github/workflows/eid-spring-boot-build-publish-image.yml
@@ -1,4 +1,4 @@
-name: eID build/publish Docker image 
+name: eID build/publish Docker image
 
 on:
   workflow_call:
@@ -10,6 +10,11 @@ on:
       java-version:
         description: Main version of java
         default: '11'
+        required: false
+        type: string
+      kustomize-overlay:
+        description: Kustomize overlay to use for image update
+        default: 'latest'
         required: false
         type: string
     secrets:
@@ -124,4 +129,4 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}"}'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","kustomize-overlay":"${{inputs.kustomize-overlay}}"}'

--- a/.github/workflows/eid-update-image-version.yml
+++ b/.github/workflows/eid-update-image-version.yml
@@ -25,6 +25,11 @@ on:
         default: 'update-version'
         required: false
         type: string
+      kustomize-overlay:
+        description: Kustomize overlay to use for image update
+        default: 'latest'
+        required: false
+        type: string
     secrets:
       eid-build-token:
         description: Token from eid-build
@@ -46,4 +51,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}"}'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","kustomize-overlay":"${{inputs.kustomize-overlay}}"}'


### PR DESCRIPTION
To be able to choose what Kustomize overlay to update during image updates (e.g. `latest` or `stable`), we need to support this from image update pipelines in app repositories. The app repos will never override the default (i.e. `latest`), but promotion pipelines will override this to be able to use `stable` (or similar). Promotion pipelines will typically be manual pipelines within cd-repos like https://github.com/felleslosninger/idporten-cd.
