### PR TITLE
ID-1863: sende med jira-id og pusher til kubernetes repo

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -129,7 +129,7 @@ jobs:
             text: ${{ github.event.head_commit.message }}
             regex: '^([a-zA-Z]{2,6}-[\d]+)(.+)'
         - id: output-jira-id
-          if: ${{ steps.regex-match-id.outputs.match != '' }}
+          if: ${{ steps.regex-find-jira-id.outputs.match != '' }}
           run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
         - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
           uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5 # pin@v2

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -137,4 +137,4 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","kustomize-overlay":"${{inputs.kustomize-overlay}}"},"jira-id":"${{env.JIRA_ID}}","pusher":"${{ github.event.pusher.name }}"'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","kustomize-overlay":"${{inputs.kustomize-overlay}}","jira-id":"${{env.JIRA_ID}}","pusher":"${{ github.event.pusher.name }}"}'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -123,10 +123,18 @@ jobs:
             ALLURE_USER: ${{ secrets.allure-user }}
             ALLURE_PASSWORD: ${{ secrets.allure-password }}
             MULTI_MODULE: "false"
+        - uses: actions-ecosystem/action-regex-match@v2
+          id: regex-find-jira-id
+          with:
+            text: ${{ github.event.head_commit.message }}
+            regex: '^([a-zA-Z]{2,6}-[\d]+)(.+)'
+        - id: output-jira-id
+          if: ${{ steps.regex-match-id.outputs.match != '' }}
+          run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
         - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
           uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","kustomize-overlay":"${{inputs.kustomize-overlay}}"}'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","kustomize-overlay":"${{inputs.kustomize-overlay}}"},"jira-id":"${{env.JIRA_ID}}","pusher":"${{ github.event.pusher.name }}"'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -51,7 +51,7 @@ jobs:
           text: ${{ github.event.head_commit.message }}
           regex: '^([a-zA-Z]{2,6}-[\d]+)(.+)'
       - id: output-jira-id
-        if: ${{ steps.regex-match-id.outputs.match != '' }}
+        if: ${{ steps.regex-find-jira-id.outputs.match != '' }}
         run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
       - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
         uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5 # pin@v2

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -45,10 +45,18 @@ jobs:
     steps:
       - name: Log input parameters
         run: echo ${{inputs.image-version}} - ${{inputs.image-digest}} - ${{env.IMAGE-NAME}}
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-find-jira-id
+        with:
+          text: ${{ github.event.head_commit.message }}
+          regex: '^([a-zA-Z]{2,6}-[\d]+)(.+)'
+      - id: output-jira-id
+        if: ${{ steps.regex-match-id.outputs.match != '' }}
+        run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
       - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
         uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","kustomize-overlay":"${{inputs.kustomize-overlay}}"}'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","kustomize-overlay":"${{inputs.kustomize-overlay}}","jira-id":"${{env.JIRA_ID}}","pusher":"${{ github.event.pusher.name }}"}'


### PR DESCRIPTION
Parse last commit message for jira-id, if found in start of commit message, then add to body for dispatch to kubernetes-config repo (idporten-cd/minid-cd/etc). Can be used to add to PR title to trace changes better. Maybe ignore dependabot issues?
Attribute: `jira-id`

Also add pusher, might be nice to have as assigne on PR in konfig-repo?
Attribute: `pusher`

Or should we add a new attribute with labels? e.g. dependabot, auto-deploy/or not auto-deploy? Can be an array...