### PR TITLE
AOS-81: need C-libraries in docker image

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -7,6 +7,11 @@ on:
         description: Name of Docker image
         required: true
         type: string
+      image-pack:
+        description: Docker image pack of tiny, base or full
+        default: tiny
+        required: false
+        type: string
       java-version:
         description: Main version of java
         default: '11'
@@ -100,7 +105,7 @@ jobs:
         - name: Maven update version used in application.yaml
           run: mvn versions:set -B -DnewVersion="$IMAGETAG"
         - name: Build image with Maven/Spring Boot
-          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:${{ inputs.image-pack }}
         - name: Container image scan
           uses: Azure/container-scan@v0
           with:


### PR DESCRIPTION
Default 'tiny' Paketo build pack does not contain required libstdc++.so for RocksDB (internal Kafka aggregation DB).

Supported packs are documented here: https://github.com/paketo-buildpacks/stacks