### PR TITLE
ID-2149: sbom-artifact-name without slash

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -104,7 +104,7 @@ jobs:
           id: sbom-name
           run: |
             SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
-            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> $GITHUB_OUTPUT
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
         - uses: anchore/sbom-action@v0
           with:
             image: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -100,10 +100,15 @@ jobs:
             token: ${{ github.token }}
 #           trivy-version: 0.22.0
             severity-threshold: HIGH
+        - name: Create SBOM artifact-name
+          id: sbom-name
+          run: |
+            SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> $GITHUB_OUTPUT
         - uses: anchore/sbom-action@v0
           with:
             image: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
-            artifact-name: sbom-${{env.IMAGETAG}}.spdx
+            artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: 'Login Azure docker container registery'
           uses: azure/docker-login@v1
           with:

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -119,7 +119,7 @@ jobs:
           id: sbom-name
           run: |
             SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
-            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> $GITHUB_OUTPUT
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
         - uses: anchore/sbom-action@v0
           with:
             image: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -115,10 +115,15 @@ jobs:
             token: ${{ github.token }}
 #           trivy-version: 0.22.0
             severity-threshold: HIGH
+        - name: Create SBOM artifact-name
+          id: sbom-name
+          run: |
+            SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> $GITHUB_OUTPUT
         - uses: anchore/sbom-action@v0
           with:
             image: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
-            artifact-name: sbom-${{env.IMAGETAG}}.spdx
+            artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: 'Login Azure docker container registery'
           uses: azure/docker-login@v1
           with:

--- a/.github/workflows/spring-boot-container-scan.yml
+++ b/.github/workflows/spring-boot-container-scan.yml
@@ -65,10 +65,15 @@ jobs:
               }]
         - name: Build image with Maven/Spring Boot (skipTests)
           run: mvn -DskipTests -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+        - name: Create SBOM artifact-name
+          id: sbom-name
+          run: |
+            SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> $GITHUB_OUTPUT
         - uses: anchore/sbom-action@v0
           with:
             image: ${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
-            artifact-name: sbom-${{env.IMAGETAG}}.spdx
+            artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: Container scan for vulnerabilties
           uses: Azure/container-scan@v0
           with:

--- a/.github/workflows/spring-boot-container-scan.yml
+++ b/.github/workflows/spring-boot-container-scan.yml
@@ -69,7 +69,7 @@ jobs:
           id: sbom-name
           run: |
             SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
-            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> $GITHUB_OUTPUT
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
         - uses: anchore/sbom-action@v0
           with:
             image: ${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}


### PR DESCRIPTION
Bytte ut slash med bindestrek, slik at f.eks. idporten/testid-> idporten-testid som [sbom-idporten-testid-2022-10-26-1149-3cb60b0f.spdx](https://github.com/felleslosninger/idporten-test-eid/suites/8969676488/artifacts/412414076)

Testa ut branchen på TestID her: https://github.com/felleslosninger/idporten-test-eid/actions/runs/3328726245 (sjå sbom-fil i summery).