### PR TITLE
ID-2383: setje offline mode for trivy sidan container-scan kall feilar med timeout

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -19,7 +19,7 @@ on:
         type: string
       container-scan-enabled:
         description: Container-scan is default enabled, disable this with caution since vulnerabilities might enter production without scan
-        default: false
+        default: true
         type: boolean
     secrets:
       eid-build-token:
@@ -52,6 +52,8 @@ jobs:
       env:
         IMAGE-NAME: ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
+        #TRIVY_TIMEOUT: <tid>
+        TRIVY_OFFLINE_SCAN: true
       steps:
         - name: Set imagetag as env variable
           run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         IMAGE-NAME: ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
-        #TRIVY_TIMEOUT: <tid>
+        #TRIVY_TIMEOUT: "15m"
         TRIVY_OFFLINE_SCAN: true
       steps:
         - name: Set imagetag as env variable

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -64,7 +64,7 @@ jobs:
       env:
         IMAGE-NAME:  ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
-        #TRIVY_TIMEOUT: <tid>
+        #TRIVY_TIMEOUT: "15m"
         TRIVY_OFFLINE_SCAN: true
       outputs:
         imagetag: ${{ steps.output-image-tag.outputs.imagetag }}

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
       container-scan-enabled:
         description: Container-scan is default enabled, disable this with caution since vulnerabilities might enter production without scan
-        default: false
+        default: true
         type: boolean
     secrets:
       eid-build-token:
@@ -64,6 +64,8 @@ jobs:
       env:
         IMAGE-NAME:  ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
+        #TRIVY_TIMEOUT: <tid>
+        TRIVY_OFFLINE_SCAN: true
       outputs:
         imagetag: ${{ steps.output-image-tag.outputs.imagetag }}
         imagedigest: ${{ steps.output-image-digest.outputs.imagedigest }}

--- a/.github/workflows/spring-boot-container-scan.yml
+++ b/.github/workflows/spring-boot-container-scan.yml
@@ -35,53 +35,53 @@ jobs:
       env:
         IMAGE-NAME:  ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
+        #TRIVY_TIMEOUT: <tid>
+        TRIVY_OFFLINE_SCAN: true
       steps:
-        - name: disabled
-          run: echo "THIS JOB IS DISABLED FOR NOW!"
-#        - name: Set imagetag as env variable
-#          run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"
-#        - uses: actions/checkout@v3
-#        - name: Set up JDK ${{ inputs.java-version }}
-#          uses: actions/setup-java@v3
-#          with:
-#            distribution: 'liberica'
-#            java-version: ${{ inputs.java-version }}
-#        - name: Cache Maven packages
-#          uses: actions/cache@v3.0.11
-#          with:
-#            path: ~/.m2
-#            key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-#            restore-keys: ${{ runner.os }}-m2
-#        - uses: s4u/maven-settings-action@v2.8.0
-#          with:
-#            servers: |
-#              [{
-#                  "id": "github-oidc-sdk",
-#                  "username": "${{ secrets.maven-user }}",
-#                  "password": "${{ secrets.maven-password }}"
-#              },
-#              {
-#                "id": "github",
-#                "username": "${{ secrets.maven-user }}",
-#                "password": "${{ secrets.maven-password }}"
-#              }]
-#        - name: Build image with Maven/Spring Boot (skipTests)
-#          run: mvn -DskipTests -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
-#        - name: Create SBOM artifact-name
-#          id: sbom-name
-#          run: |
-#            SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
-#            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
-#        - uses: anchore/sbom-action@v0
-#          with:
-#            image: ${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
-#            artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
-#        - name: Container scan for vulnerabilties
-#          uses: Azure/container-scan@v0
-#          with:
-#            # Docker image to scan
-#            image-name: ${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
-#            # Minimum severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
-#            token: ${{ github.token }}
-#            # trivy-version: 0.36.0
-#            severity-threshold: HIGH
+        - name: Set imagetag as env variable
+          run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"
+        - uses: actions/checkout@v3
+        - name: Set up JDK ${{ inputs.java-version }}
+          uses: actions/setup-java@v3
+          with:
+            distribution: 'liberica'
+            java-version: ${{ inputs.java-version }}
+        - name: Cache Maven packages
+          uses: actions/cache@v3.0.11
+          with:
+            path: ~/.m2
+            key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+            restore-keys: ${{ runner.os }}-m2
+        - uses: s4u/maven-settings-action@v2.8.0
+          with:
+            servers: |
+              [{
+                  "id": "github-oidc-sdk",
+                  "username": "${{ secrets.maven-user }}",
+                  "password": "${{ secrets.maven-password }}"
+              },
+              {
+                "id": "github",
+                "username": "${{ secrets.maven-user }}",
+                "password": "${{ secrets.maven-password }}"
+              }]
+        - name: Build image with Maven/Spring Boot (skipTests)
+          run: mvn -DskipTests -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+        - name: Create SBOM artifact-name
+          id: sbom-name
+          run: |
+            SBOM_NAME=$(echo ${{env.IMAGE-NAME}} | tr '/' '-')
+            echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
+        - uses: anchore/sbom-action@v0
+          with:
+            image: ${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
+        - name: Container scan for vulnerabilties
+          uses: Azure/container-scan@v0
+          with:
+            # Docker image to scan
+            image-name: ${{ inputs.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            # Minimum severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
+            token: ${{ github.token }}
+            # trivy-version: 0.36.0
+            severity-threshold: HIGH

--- a/.github/workflows/spring-boot-container-scan.yml
+++ b/.github/workflows/spring-boot-container-scan.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         IMAGE-NAME:  ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
-        #TRIVY_TIMEOUT: <tid>
+        #TRIVY_TIMEOUT: "15m"
         TRIVY_OFFLINE_SCAN: true
       steps:
         - name: Set imagetag as env variable


### PR DESCRIPTION
Setje trivy til offline, tips til konfig frå BE. :)
https://github.com/aquasecurity/trivy/issues/3421

Så vidt eg har skjønt får ein lasta ned trivy binary ok, men får ikkje lasta ned nyaste CVEs.

Endre tilbake container-scan til å vera default på. 

Testa ut på maskinporten repoet på ein PR: 
![image](https://user-images.githubusercontent.com/8371957/212300125-7199ec04-7991-4449-9ea1-21f09e1551b4.png)
