### PR TITLE
ID-2389: Enable online check for container-scan

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -17,9 +17,9 @@ on:
         default: 'latest'
         required: false
         type: string
-      container-scan-enabled:
-        description: Container-scan is default enabled, disable this with caution since vulnerabilities might enter production without scan
-        default: true
+      container-scan-offline-mode:
+        description: Container-scan is default download updated CVE definitions via Trivy, enable offline on download problems
+        default: false
         type: boolean
     secrets:
       eid-build-token:
@@ -53,7 +53,7 @@ jobs:
         IMAGE-NAME: ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
         #TRIVY_TIMEOUT: "15m"
-        TRIVY_OFFLINE_SCAN: true
+        TRIVY_OFFLINE_SCAN: ${{ inputs.container-scan-offline-mode }}
       steps:
         - name: Set imagetag as env variable
           run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"
@@ -98,7 +98,6 @@ jobs:
         - name: Build image with Maven/Spring Boot
           run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
         - name: Container image scan
-          if: ${{ inputs.container-scan-enabled }}
           uses: Azure/container-scan@v0
           with:
             # Docker image to scan

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -22,9 +22,9 @@ on:
         default: true
         required: false
         type: boolean
-      container-scan-enabled:
-        description: Container-scan is default enabled, disable this with caution since vulnerabilities might enter production without scan
-        default: true
+      container-scan-offline-mode:
+        description: Container-scan is default download updated CVE definitions via Trivy, enable offline on download problems
+        default: false
         type: boolean
     secrets:
       eid-build-token:
@@ -65,7 +65,7 @@ jobs:
         IMAGE-NAME:  ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
         #TRIVY_TIMEOUT: "15m"
-        TRIVY_OFFLINE_SCAN: true
+        TRIVY_OFFLINE_SCAN: ${{ inputs.container-scan-offline-mode }}
       outputs:
         imagetag: ${{ steps.output-image-tag.outputs.imagetag }}
         imagedigest: ${{ steps.output-image-digest.outputs.imagedigest }}
@@ -113,7 +113,6 @@ jobs:
         - name: Build image with Maven/Spring Boot
           run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:${{ inputs.image-pack }}
         - name: Container image scan
-          if: ${{ inputs.container-scan-enabled }}
           uses: Azure/container-scan@v0
           with:
             # Docker image to scan

--- a/.github/workflows/spring-boot-container-scan.yml
+++ b/.github/workflows/spring-boot-container-scan.yml
@@ -17,6 +17,10 @@ on:
         default: '11'
         required: false
         type: string
+      container-scan-offline-mode:
+        description: Container-scan is default download updated CVE definitions via Trivy, enable offline on download problems
+        default: false
+        type: boolean
     secrets:
       eid-build-token:
         description: Token from eid-build
@@ -36,7 +40,7 @@ jobs:
         IMAGE-NAME:  ${{ inputs.image-name }}
         DOCKLE_HOST: "unix:///var/run/docker.sock"
         #TRIVY_TIMEOUT: "15m"
-        TRIVY_OFFLINE_SCAN: true
+        TRIVY_OFFLINE_SCAN: ${{ inputs.container-scan-offline-mode }}
       steps:
         - name: Set imagetag as env variable
           run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ See [how to configure](docs/java-library.md) for more details and examples for J
 ## Syntax check of the action in this repository
 See [check-syntax.yml](.github/workflows/check-syntax.yml) for details. Only for internal use in current repository.
 
+## Container scan
+Uses Trivy https://github.com/aquasecurity/trivy through action [Azure/container-scan](https://github.com/Azure/container-scan). Will soon be replaced by Trivy action directly.
+You can test container scan locally by download trivy and run `trivy image <my-image:latest>`.


### PR DESCRIPTION
New patch from Trivy 10.2: [https://github.com/aquasecurity/trivy/releases/tag/v0.37.2](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Faquasecurity%2Ftrivy%2Freleases%2Ftag%2Fv0.37.2&data=05%7C01%7C%7C0c955529b35f4ecf152808db0b0e1b1b%7C008e560f08af4ceca056b35447503991%7C1%7C0%7C638115927434779381%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=OI4paFdI9deNJDoYV004E4DX4IymFpSXuCmCNFIbtCY%3D&reserved=0)

------

And add possibility to toogle off-line mode for container-scan. Remove possibility to turn container-scan compeletly off.

Maven central has now solved timeout issue (20.01.23): [Maven Central Status](https://status.maven.org/)

Tok ein test av branchen her: https://github.com/felleslosninger/idporten-user-service/actions/runs/3984047283/jobs/6829882748 - gjennomførte container-scan på 4min.