### PR TITLE
PF-549 - Sende meir metadata om endring i applikasjonsrepo

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -160,7 +160,6 @@ jobs:
             repository: 'felleslosninger/idporten-cd'
             client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
-          if: ${{ env.DEPENDABOT == 'false' }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -157,12 +157,12 @@ jobs:
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
-            repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+            repository: 'felleslosninger/plattform-test-cd'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
-            repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+            repository: 'felleslosninger/plattform-test-cd'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -149,7 +149,7 @@ jobs:
         - id: check_dependabot
           run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependabot') }}" >> "$GITHUB_ENV"
         - id: output-dependabot
-          if: ${{ steps.regex-find-jira-id.outputs.match == '' && ${{ env.DEPENDABOT }} }}
+          if: ${{ steps.regex-find-jira-id.outputs.match == '' && env.DEPENDABOT }}
           run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
           if: ${{ env.DEPENDABOT }}

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -156,7 +156,7 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           if: ${{steps.check_dependabot.outputs.result == 'false'}}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -164,4 +164,4 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ fromJson(steps.get_issues.outputs.data)[0].number }}", "pr-labels":"${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}", "sha":"${{ github.sha }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -158,7 +158,7 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           if: ${{ env.DEPENDABOT == 'false' }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -166,4 +166,4 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -157,7 +157,7 @@ jobs:
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
-            repository: 'felleslosninger/plattform-test-cd'
+            repository: 'felleslosninger/idporten-cd'
             client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           if: ${{ env.DEPENDABOT == 'false' }}
@@ -165,5 +165,5 @@ jobs:
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
-            repository: 'felleslosninger/plattform-test-cd'
+            repository: 'felleslosninger/idporten-cd'
             client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -99,7 +99,7 @@ jobs:
         - name: Maven update version used in application.yaml
           run: mvn versions:set -B -DnewVersion="$IMAGETAG"
         - name: Build image with Maven/Spring Boot
-          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{env.IMAGE-NAME}}:${{env.IMAGETAG} -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{env.IMAGE-NAME}}:${{env.IMAGETAG}} -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
         - name: Container image scan
           uses: Azure/container-scan@v0
           with:
@@ -146,11 +146,13 @@ jobs:
         - run: |
               echo "PR_LABELS=${{ join(fromJSON(steps.get_labels.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
               echo "PR_NUMBER=${{ fromJson(steps.get_labels.outputs.data)[0].number }}" >> "$GITHUB_ENV"
+        - id: check_dependabot
+          run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependabot') }}" >> "$GITHUB_ENV"
         - id: output-dependabot
-          if: ${{ steps.regex-find-jira-id.outputs.match == '' && contains(${{ env.PR_LABELS }}, 'dependabot')}}
+          if: ${{ steps.regex-find-jira-id.outputs.match == '' && ${{ env.DEPENDABOT }} }}
           run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
-          if: ${{steps.check_dependabot.outputs.result == 'true'}}
+          if: ${{ env.DEPENDABOT }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
@@ -158,7 +160,7 @@ jobs:
             repository: 'felleslosninger/idporten-cd'
             client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
-          if: ${{steps.check_dependabot.outputs.result == 'false'}}
+          if: ${{ env.DEPENDABOT == 'false' }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -158,11 +158,11 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/plattform-test-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"$${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/plattform-test-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -160,6 +160,7 @@ jobs:
             repository: 'felleslosninger/plattform-test-cd'
             client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
+          if: ${{ env.DEPENDABOT == 'false' }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -158,7 +158,7 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           if: ${{ env.DEPENDABOT == 'false' }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -166,4 +166,4 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -58,7 +58,7 @@ jobs:
           run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"
         - name: Set image and application name
           run: |
-             echo "IMAGE-NAME=${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
+             echo "IMAGE-NAME=${{ secrets.registry-url }}/${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
              echo "APPLICATION-NAME=${{ inputs.application-name || env.REPOSITORY-NAME  }}" >> "$GITHUB_ENV"
         - uses: actions/checkout@v3
         - name: yaml-lint
@@ -99,12 +99,12 @@ jobs:
         - name: Maven update version used in application.yaml
           run: mvn versions:set -B -DnewVersion="$IMAGETAG"
         - name: Build image with Maven/Spring Boot
-          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
+          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{env.IMAGE-NAME}}:${{env.IMAGETAG} -Dspring-boot.build-image.builder=paketobuildpacks/builder:tiny
         - name: Container image scan
           uses: Azure/container-scan@v0
           with:
             # Docker image to scan
-            image-name: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            image-name: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             # Minimum severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
             token: ${{ github.token }}
 #           trivy-version: 0.22.0
@@ -116,7 +116,7 @@ jobs:
             echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
         - uses: anchore/sbom-action@v0
           with:
-            image: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            image: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: 'Login Azure docker container registery'
           uses: azure/docker-login@v1
@@ -126,9 +126,9 @@ jobs:
             password: ${{ secrets.registry-password }}
         - name: 'Push image'
           run:
-            docker push ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            docker push ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
         - run:
-            echo "IMAGE_DIGEST=$(docker inspect --format='{{.RepoDigests}}' ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}|cut -d '@' -f 2|cut -d ']' -f 1)" >> "$GITHUB_ENV"
+            echo "IMAGE_DIGEST=$(docker inspect --format='{{.RepoDigests}}' ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}|cut -d '@' -f 2|cut -d ']' -f 1)" >> "$GITHUB_ENV"
         - uses: actions-ecosystem/action-regex-match@v2
           id: regex-find-jira-id
           with:
@@ -137,39 +137,31 @@ jobs:
         - id: output-jira-id
           if: ${{ steps.regex-find-jira-id.outputs.match != '' }}
           run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
-        - name: Check PR label for dependabot
-          id: check_dependabot
-          uses: shioyang/check-pr-labels-on-push-action@v1.0.9
+        - uses: octokit/request-action@v2.x
+          id: get_labels
           with:
-            github-token: ${{ secrets.eid-build-token }}
-            labels: '["dependencies"]'
-        - name: Check PR label for manual-deploy
-          id: check_manual_deploy
-          uses: shioyang/check-pr-labels-on-push-action@v1.0.9
-          with:
-            github-token: ${{ secrets.eid-build-token }}
-            labels: '["manual-deploy"]'
-        - name: Get PR labels
-          id: pr-labels
-          uses: ruben-baez-mojix-com/git-labels@v0.0.4
-          with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
+            route: GET /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - run: |
+              echo "PR_LABELS=${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
+              echo "PR_NUMBER=${{ fromJson(steps.get_issues.outputs.data)[0].number }}" >> "$GITHUB_ENV"
         - id: output-dependabot
-          if: ${{ steps.regex-find-jira-id.outputs.match == '' && steps.check_dependabot.outputs.result == 'true'}}
+          if: ${{ steps.regex-find-jira-id.outputs.match == '' && contains(${{ env.PR_LABELS }}, 'dependabot')}}
           run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
-        - name: 'update Kubernetes for new version of image ${{ inputs.image-name }} (Dependabot)'
+        - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
           if: ${{steps.check_dependabot.outputs.result == 'true'}}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","manual-deploy":${{ steps.check_manual_deploy.outputs.result }},"jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-labels":${{toJSON(steps.pr-labels.outputs.result)}} }'
-        - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+        - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           if: ${{steps.check_dependabot.outputs.result == 'false'}}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/idporten-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","manual-deploy":${{ steps.check_manual_deploy.outputs.result }},"jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }}, "pr-labels":${{toJSON(steps.pr-labels.outputs.result)}} }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ fromJson(steps.get_issues.outputs.data)[0].number }}", "pr-labels":"${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}", "sha":"${{ github.sha }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -158,11 +158,11 @@ jobs:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/plattform-test-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"$${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}
             event-type: update-version
             repository: 'felleslosninger/plattform-test-cd'
-            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
+            client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -144,8 +144,8 @@ jobs:
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - run: |
-              echo "PR_LABELS=${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
-              echo "PR_NUMBER=${{ fromJson(steps.get_issues.outputs.data)[0].number }}" >> "$GITHUB_ENV"
+              echo "PR_LABELS=${{ join(fromJSON(steps.get_labels.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
+              echo "PR_NUMBER=${{ fromJson(steps.get_labels.outputs.data)[0].number }}" >> "$GITHUB_ENV"
         - id: output-dependabot
           if: ${{ steps.regex-find-jira-id.outputs.match == '' && contains(${{ env.PR_LABELS }}, 'dependabot')}}
           run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -147,12 +147,12 @@ jobs:
               echo "PR_LABELS=${{ join(fromJSON(steps.get_labels.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
               echo "PR_NUMBER=${{ fromJson(steps.get_labels.outputs.data)[0].number }}" >> "$GITHUB_ENV"
         - id: check_dependabot
-          run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependabot') }}" >> "$GITHUB_ENV"
+          run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependencies') }}" >> "$GITHUB_ENV"
         - id: output-dependabot
-          if: ${{ steps.regex-find-jira-id.outputs.match == '' && env.DEPENDABOT }}
+          if: ${{ steps.regex-find-jira-id.outputs.match == '' && env.DEPENDABOT == 'true' }}
           run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
         - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
-          if: ${{ env.DEPENDABOT }}
+          if: ${{ env.DEPENDABOT == 'true' }}
           uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
           with:
             token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -74,7 +74,7 @@ jobs:
           run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"
         - name: Set IMAGE-NAME env variable
           run: |
-             echo "IMAGE-NAME=${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
+             echo "IMAGE-NAME=${{ secrets.registry-url }}/${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
         - uses: actions/checkout@v3
         - name: yaml-lint
           uses: ibiqlik/action-yamllint@v3
@@ -114,12 +114,12 @@ jobs:
         - name: Maven update version used in application.yaml
           run: mvn versions:set -B -DnewVersion="$IMAGETAG"
         - name: Build image with Maven/Spring Boot
-          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:${{ inputs.image-pack }}
+          run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{env.IMAGE-NAME}}:"$IMAGETAG" -Dspring-boot.build-image.builder=paketobuildpacks/builder:${{ inputs.image-pack }}
         - name: Container image scan
           uses: Azure/container-scan@v0
           with:
             # Docker image to scan
-            image-name: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            image-name: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             # Minimum severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
             token: ${{ github.token }}
 #           trivy-version: 0.22.0
@@ -131,7 +131,7 @@ jobs:
             echo "SBOM_ARTIFACT_ID=$SBOM_NAME" >> "$GITHUB_OUTPUT"
         - uses: anchore/sbom-action@v0
           with:
-            image: ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            image: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: 'Login Azure docker container registery'
           uses: azure/docker-login@v1
@@ -141,9 +141,9 @@ jobs:
             password: ${{ secrets.registry-password }}
         - name: 'Push image'
           run:
-            docker push ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
+            docker push ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
         - run:
-            echo "IMAGE_DIGEST=$(docker inspect --format='{{.RepoDigests}}' ${{ secrets.registry-url }}/${{env.IMAGE-NAME}}:${{env.IMAGETAG}}|cut -d '@' -f 2|cut -d ']' -f 1)" >> "$GITHUB_ENV"
+            echo "IMAGE_DIGEST=$(docker inspect --format='{{.RepoDigests}}' ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}|cut -d '@' -f 2|cut -d ']' -f 1)" >> "$GITHUB_ENV"
         - id: output-image-tag
           run: echo "imagetag=${{env.IMAGETAG}}" >> "$GITHUB_OUTPUT"
         - id: output-image-digest

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
         if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -90,4 +90,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -73,7 +73,7 @@ jobs:
       - id: check_dependabot
         run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependabot') }}" >> "$GITHUB_ENV"
       - id: output-dependabot
-        if: ${{ steps.regex-find-jira-id.outputs.match == '' && steps.check_dependabot.outputs.result == 'true'}}
+        if: ${{ steps.regex-find-jira-id.outputs.match == '' && env.DEPENDABOT }}
         run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
         if: ${{ env.DEPENDABOT }}

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -61,39 +61,31 @@ jobs:
       - id: output-jira-id
         if: ${{ steps.regex-find-jira-id.outputs.match != '' }}
         run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
-      - name: Check PR label for dependabot
-        id: check_dependabot
-        uses: shioyang/check-pr-labels-on-push-action@v1.0.9
+      - uses: octokit/request-action@v2.x
+        id: get_labels
         with:
-          github-token: ${{ secrets.eid-build-token }}
-          labels: '["dependencies"]'
-      - name: Check PR label for manual-deploy
-        id: check_manual_deploy
-        uses: shioyang/check-pr-labels-on-push-action@v1.0.9
-        with:
-          github-token: ${{ secrets.eid-build-token }}
-          labels: '["manual-deploy"]'
+          route: GET /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+            echo "PR_LABELS=${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
+            echo "PR_NUMBER=${{ fromJson(steps.get_issues.outputs.data)[0].number }}" >> "$GITHUB_ENV"
       - id: output-dependabot
         if: ${{ steps.regex-find-jira-id.outputs.match == '' && steps.check_dependabot.outputs.result == 'true'}}
         run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
-      - name: Get PR labels
-        id: pr-labels
-        uses: ruben-baez-mojix-com/git-labels@v0.0.4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'update Kubernetes for new version of image ${{ inputs.image-name }} (Dependabot)'
+      - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
         if: ${{steps.check_dependabot.outputs.result == 'true'}}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","manual-deploy":${{ steps.check_manual_deploy.outputs.result }},"jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}", "pr-labels":${{toJSON(steps.pr-labels.outputs.result)}}, "kustomize-overlay":"${{inputs.kustomize-overlay}}" }'
-      - name: 'update Kubernetes for new version of image ${{ inputs.image-name }}'
-        if: ${{ steps.check_dependabot.outputs.result == 'false'}}
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+      - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
+        if: ${{steps.check_dependabot.outputs.result == 'false'}}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "registry-url": "${{secrets.registry-url}}", "image": "${{secrets.registry-url}}/${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","manual-deploy":${{ steps.check_manual_deploy.outputs.result }},"jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }}, "pr-labels":${{toJSON(steps.pr-labels.outputs.result)}}, "kustomize-overlay":"${{inputs.kustomize-overlay}}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ fromJson(steps.get_issues.outputs.data)[0].number }}", "pr-labels":"${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}", "sha":"${{ github.sha }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -29,11 +29,6 @@ on:
         default: 'update-version'
         required: false
         type: string
-      kustomize-overlay:
-        description: Kustomize overlay to use for image update
-        default: 'latest'
-        required: false
-        type: string
     secrets:
       eid-build-token:
         description: Token from eid-build

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -84,9 +84,10 @@ jobs:
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
           client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
+        if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -88,4 +88,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ fromJson(steps.get_issues.outputs.data)[0].number }}", "pr-labels":"${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}", "sha":"${{ github.sha }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
         if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -90,4 +90,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -70,11 +70,13 @@ jobs:
       - run: |
             echo "PR_LABELS=${{ join(fromJSON(steps.get_labels.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
             echo "PR_NUMBER=${{ fromJson(steps.get_labels.outputs.data)[0].number }}" >> "$GITHUB_ENV"
+      - id: check_dependabot
+        run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependabot') }}" >> "$GITHUB_ENV"
       - id: output-dependabot
         if: ${{ steps.regex-find-jira-id.outputs.match == '' && steps.check_dependabot.outputs.result == 'true'}}
         run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
-        if: ${{steps.check_dependabot.outputs.result == 'true'}}
+        if: ${{ env.DEPENDABOT }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}
@@ -82,7 +84,7 @@ jobs:
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
           client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{env.IMAGETAG}}@${{env.IMAGE_DIGEST}}","version":"${{env.IMAGETAG}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
-        if: ${{steps.check_dependabot.outputs.result == 'false'}}
+        if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -90,4 +90,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
         if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -90,4 +90,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ env.REPOSITORY-NAME }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}","pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
         if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
@@ -90,4 +90,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}","image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":${{ toJSON(github.event.head_commit.author) }},"pr-number":"${{ env.PR_NUMBER }}","pr-labels":"${{ env.PR_LABELS }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -84,7 +84,6 @@ jobs:
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
           client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}}'
-        if: ${{ env.DEPENDABOT == 'false' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -90,4 +90,4 @@ jobs:
           token: ${{ secrets.eid-build-token }}
           event-type: ${{ inputs.kubernetes-repo-event }}
           repository: 'felleslosninger/${{ inputs.kubernetes-repo }}'
-          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","author":"${{ toJSON(github.event.head_commit.author) }}", "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'
+          client-payload: '{"image-name": "${{env.IMAGE-NAME}}", "image": "${{env.IMAGE-NAME}}:${{inputs.image-version}}@${{inputs.image-digest}}","version":"${{inputs.image-version}}","application-name":"${{env.APPLICATION-NAME}}","jira-id":"${{env.JIRA_ID}}","actor":"${{github.event.pusher.name }}",  "pr-number":"${{ env.PR_NUMBER }}", "pr-labels":"${{ env.PR_LABELS }}", "sha":"${{ github.sha }}", "repository":"${{ github.repository }}" }'

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -71,12 +71,12 @@ jobs:
             echo "PR_LABELS=${{ join(fromJSON(steps.get_labels.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
             echo "PR_NUMBER=${{ fromJson(steps.get_labels.outputs.data)[0].number }}" >> "$GITHUB_ENV"
       - id: check_dependabot
-        run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependabot') }}" >> "$GITHUB_ENV"
+        run: echo "DEPENDABOT=${{ contains(env.PR_LABELS, 'dependencies') }}" >> "$GITHUB_ENV"
       - id: output-dependabot
-        if: ${{ steps.regex-find-jira-id.outputs.match == '' && env.DEPENDABOT }}
+        if: ${{ steps.regex-find-jira-id.outputs.match == '' && env.DEPENDABOT == 'true' }}
         run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"
       - name: 'update Kubernetes for new version of image ${{env.IMAGE-NAME}} (Dependabot)'
-        if: ${{ env.DEPENDABOT }}
+        if: ${{ env.DEPENDABOT == 'true' }}
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           token: ${{ secrets.eid-build-token }}

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -68,8 +68,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-            echo "PR_LABELS=${{ join(fromJSON(steps.get_issues.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
-            echo "PR_NUMBER=${{ fromJson(steps.get_issues.outputs.data)[0].number }}" >> "$GITHUB_ENV"
+            echo "PR_LABELS=${{ join(fromJSON(steps.get_labels.outputs.data)[0].labels.*.name) }}" >> "$GITHUB_ENV"
+            echo "PR_NUMBER=${{ fromJson(steps.get_labels.outputs.data)[0].number }}" >> "$GITHUB_ENV"
       - id: output-dependabot
         if: ${{ steps.regex-find-jira-id.outputs.match == '' && steps.check_dependabot.outputs.result == 'true'}}
         run: echo "JIRA_ID=Dependabot" >> "$GITHUB_ENV"

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo ${{inputs.image-version}} - ${{inputs.image-digest}} - ${{env.IMAGE-NAME}}
       - name: Set image and application name
         run: |
-             echo "IMAGE-NAME=${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
+             echo "IMAGE-NAME=${{ secrets.registry-url }}/${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
              echo "APPLICATION-NAME=${{ inputs.application-name || env.REPOSITORY-NAME  }}" >> "$GITHUB_ENV"
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex-find-jira-id


### PR DESCRIPTION
For å kunne spore bedre endringane heile vegen til produksjon treng ein meir metadata som no blir sendt.

Har i tillegg refaktorert litt og bytta ut nokre tredjeparts actions for pr labels