### PR TITLE
ID-2198: find jira-id by regex not deprecated action (set-output)

### DIFF
--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -131,14 +131,15 @@ jobs:
             docker push ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
         - run:
             echo "IMAGE_DIGEST=$(docker inspect --format='{{.RepoDigests}}' ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}|cut -d '@' -f 2|cut -d ']' -f 1)" >> "$GITHUB_ENV"
-        - uses: actions-ecosystem/action-regex-match@v2
+        - name: Find jira-id
           id: regex-find-jira-id
-          with:
-            text: ${{ github.event.head_commit.message }}
-            regex: '^([a-zA-Z]{2,6}-[\d]+)(.+)'
+          run: |
+              JIID=$(echo '${{ github.event.head_commit.message }}' | 
+              sed -E 's/^([a-zA-Z]{2,6}\-[0-9]+).+/\1/')
+              echo "JIRAID=$JIID" >> "$GITHUB_OUTPUT"
         - id: output-jira-id
-          if: ${{ steps.regex-find-jira-id.outputs.match != '' }}
-          run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
+          if: ${{ steps.regex-find-jira-id.outputs.JIRAID != '' }}
+          run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.JIRAID }}" >> "$GITHUB_ENV"
         - uses: octokit/request-action@v2.x
           id: get_labels
           with:

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -136,7 +136,7 @@ jobs:
           env:
             GIT_MSG: ${{ github.event.head_commit.message }}
           run: |
-              JIID=$(echo "$GIT_MSG" | 
+              JIID=$(echo "$GIT_MSG" | head -1 |
               sed -E 's/^([a-zA-Z]{2,6}\-[0-9]+).+/\1/')
               echo "JIRAID=$JIID" >> "$GITHUB_OUTPUT"
         - id: output-jira-id

--- a/.github/workflows/spring-boot-build-publish-image-config.yml
+++ b/.github/workflows/spring-boot-build-publish-image-config.yml
@@ -133,8 +133,10 @@ jobs:
             echo "IMAGE_DIGEST=$(docker inspect --format='{{.RepoDigests}}' ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}|cut -d '@' -f 2|cut -d ']' -f 1)" >> "$GITHUB_ENV"
         - name: Find jira-id
           id: regex-find-jira-id
+          env:
+            GIT_MSG: ${{ github.event.head_commit.message }}
           run: |
-              JIID=$(echo '${{ github.event.head_commit.message }}' | 
+              JIID=$(echo "$GIT_MSG" | 
               sed -E 's/^([a-zA-Z]{2,6}\-[0-9]+).+/\1/')
               echo "JIRAID=$JIID" >> "$GITHUB_OUTPUT"
         - id: output-jira-id

--- a/.github/workflows/spring-boot-build-publish-image.yml
+++ b/.github/workflows/spring-boot-build-publish-image.yml
@@ -29,7 +29,7 @@ on:
     secrets:
       eid-build-token:
         description: Token from eid-build
-        required: true
+        required: false
       maven-user:
         description: Maven user
         required: true

--- a/.github/workflows/spring-boot-container-scan.yml
+++ b/.github/workflows/spring-boot-container-scan.yml
@@ -29,7 +29,7 @@ on:
     secrets:
       eid-build-token:
         description: Token from eid-build
-        required: true
+        required: false
       maven-user:
         description: Maven user
         required: true

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -50,8 +50,10 @@ jobs:
              echo "APPLICATION-NAME=${{ inputs.application-name || env.REPOSITORY-NAME  }}" >> "$GITHUB_ENV"
       - name: Find jira-id
         id: regex-find-jira-id
+        env:
+          GIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-            JIID=$(echo '${{ github.event.head_commit.message }}' | 
+            JIID=$(echo "$GIT_MSG" | 
             sed -E 's/^([a-zA-Z]{2,6}\-[0-9]+).+/\1/')
             echo "JIRAID=$JIID" >> "$GITHUB_OUTPUT"
       - id: output-jira-id

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -51,11 +51,12 @@ jobs:
       - name: Find jira-id
         id: regex-find-jira-id
         run: |
-             JIRAID=$(echo ${{ github.event.head_commit.message }} | egrep -o '(^[a-zA-Z]{2,6}-[0-9]+)')
-             echo "::set-output name=JIRAID::$JIRAID"
+            JIID=$(echo '${{ github.event.head_commit.message }}' | 
+            sed -E 's/^([a-zA-Z]{2,6}\-[0-9]+).+/\1/')
+            echo "JIRAID=$JIID" >> "$GITHUB_OUTPUT"
       - id: output-jira-id
         if: ${{ steps.regex-find-jira-id.outputs.JIRAID != '' }}
-        run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
+        run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.JIRAID }}" >> "$GITHUB_ENV"
       - uses: octokit/request-action@v2.x
         id: get_labels
         with:

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -48,13 +48,13 @@ jobs:
         run: |
              echo "IMAGE-NAME=${{ secrets.registry-url }}/${{ inputs.image-name || env.REPOSITORY-NAME }}" >> "$GITHUB_ENV"
              echo "APPLICATION-NAME=${{ inputs.application-name || env.REPOSITORY-NAME  }}" >> "$GITHUB_ENV"
-      - uses: actions-ecosystem/action-regex-match@v2
+      - name: Find jira-id
         id: regex-find-jira-id
-        with:
-          text: ${{ github.event.head_commit.message }}
-          regex: '^([a-zA-Z]{2,6}-[\d]+)(.+)'
+        run: |
+             JIRAID=$(echo ${{ github.event.head_commit.message }} | egrep -o '(^[a-zA-Z]{2,6}-[0-9]+)')
+             echo "::set-output name=JIRAID::$JIRAID"
       - id: output-jira-id
-        if: ${{ steps.regex-find-jira-id.outputs.match != '' }}
+        if: ${{ steps.regex-find-jira-id.outputs.JIRAID != '' }}
         run: echo "JIRA_ID=${{ steps.regex-find-jira-id.outputs.group1 }}" >> "$GITHUB_ENV"
       - uses: octokit/request-action@v2.x
         id: get_labels

--- a/.github/workflows/update-image-version.yml
+++ b/.github/workflows/update-image-version.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-            JIID=$(echo "$GIT_MSG" | 
+            JIID=$(echo "$GIT_MSG" | head -1 |
             sed -E 's/^([a-zA-Z]{2,6}\-[0-9]+).+/\1/')
             echo "JIRAID=$JIID" >> "$GITHUB_OUTPUT"
       - id: output-jira-id


### PR DESCRIPTION
Also set `required:false` for eid-build-token where not used at all.